### PR TITLE
add requirement boost<=1.72, fix bug when GOROBI is not installed

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -38,7 +38,7 @@ message("-- LIMBO_BINARY_DIR ${LIMBO_BINARY_DIR}")
 find_package(ZLIB REQUIRED)
 # first try to find static libraries, then try to find dynamic ones
 set(Boost_USE_STATIC_LIBS ON) 
-find_package(Boost 1.55.0 COMPONENTS timer chrono graph)
+find_package(Boost 1.55.0...1.72.0 COMPONENTS timer chrono graph)
 if (NOT Boost_FOUND)
     set(Boost_USE_STATIC_LIBS OFF)  
     find_package(Boost 1.55.0 REQUIRED COMPONENTS timer chrono graph)

--- a/Readme.md
+++ b/Readme.md
@@ -16,7 +16,7 @@
     - Require 3.8.2 or later. 
 
 - [Boost](https://www.boost.org)
-    - Require 1.55 or later. 
+    - Require 1.55...1.72. 
     - Need to install and visible for linking. 
     - Custom installation path may require to export ```BOOST_ROOT``` for [CMake](https://cmake.org/cmake/help/v3.8/module/FindBoost.html). 
 

--- a/src/SimpleMPL.cpp
+++ b/src/SimpleMPL.cpp
@@ -2164,7 +2164,9 @@ double SimpleMPL::solve_graph_coloring(uint32_t comp_id, SimpleMPL::graph_type c
 		// Default is sdp solver
 		coloring_solver_type* ilp_pcs = NULL;
 		coloring_solver_type* dl_pcs = NULL;
+	#if GUROBI == 1
 		ilp_pcs = new lac::ILPColoringUpdated<graph_type> (sg);
+	#endif
 		// coloring_solver_type* sdp_pcs = new lac::SDPColoringCsdp<graph_type> (sg);
 		dl_pcs = new DancingLinkColoring<graph_type> (sg);
 
@@ -2192,7 +2194,9 @@ double SimpleMPL::solve_graph_coloring(uint32_t comp_id, SimpleMPL::graph_type c
 		boost::timer::cpu_timer ilp_comp_timer;
 		boost::timer::cpu_timer dl_comp_timer;
 		ilp_comp_timer.start();
+	#if GUROBI == 1
 		if(num_vertices(sg) < 500){ilp_obj = (*ilp_pcs)();}
+	#endif
 		ilp_comp_timer.stop();
 		dl_comp_timer.start();
 		dl_obj = (*dl_pcs)();


### PR DESCRIPTION
add requirement boost<=1.72
fix the bug in SimpleMPL when GOROBI is not installed